### PR TITLE
Added python-pip to the raspian build reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Building & Installing
 ---------------------
 For Raspian:
 
-    $ sudo apt-get install python-dev
+    $ sudo apt-get install python-dev python-pip
     $ sudo pip install spidev
     $ sudo python setup.py install
 


### PR DESCRIPTION
Just ran on completely clean install of raspbain and pip was not installed so added to documentation