### PR TITLE
Added information about SPI setup on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Building & Installing
 ---------------------
 For Raspian:
 
+On setup while in raspbian config or post install by running 'sudo raspi-config' you must enable SPI: 8 Advanced options > A6 SPI > Yes (Would you like the SPI interface enabled?) > OK > Yes (Would you like the SPI kernel module to be loaded by default?) > OK  
+
     $ sudo apt-get install python-dev python-pip
     $ sudo pip install spidev
     $ sudo python setup.py install


### PR DESCRIPTION
Added some additional documentation for raspian about setting up SPI either during install or after install by using sudo raspi-config. This is required to be able to run the examples and any other commends to the hardware