### PR TITLE
Changed CS0 to CE0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The breakout board has an two headers to allow daisy-chaining:
 | 1 | VCC | +5V Power | 2 | 5V0 |
 | 2 | GND | Ground | 6 | GND |
 | 3 | DIN | Data In | 19 | GPIO 10 (MOSI) |
-| 4 | CS | Chip Select | 24 | GPIO 8 (SPI CS0) |
+| 4 | CS | Chip Select | 24 | GPIO 8 (SPI CE0) |
 | 5 | CLK | Clock | 23 | GPIO 11 (SPI CLK) |
 
 Building & Installing


### PR DESCRIPTION
I found on my cobbler the pin was listed as CE0 not CS0, I checked the following 26 and 40 pin images and they seem to backup the change

26 Pin - http://www.raspberrypi-spy.co.uk/wp-content/uploads/2012/09/Raspberry-Pi-GPIO-Layout-Revision-1.png

40 pin - http://www.raspberrypi-spy.co.uk/wp-content/uploads/2014/07/Raspberry-Pi-GPIO-Layout-Model-B-Plus.png